### PR TITLE
fix: create mailboxd etc directory for appserver node

### DIFF
--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -39,6 +39,7 @@ sha256sums=(
 package() {
   mkdir -p "${pkgdir}/opt/zextras/bin/"
   mkdir -p "${pkgdir}/opt/zextras/conf/templates/"
+  mkdir -p "${pkgdir}/opt/zextras/jetty_base/etc/"
   mkdir -p "${pkgdir}/opt/zextras/jetty_base/common/endorsed/"
   mkdir -p "${pkgdir}/opt/zextras/jetty_base/common/lib/"
   mkdir -p "${pkgdir}/opt/zextras/jetty_base/webapps/zimbra/"


### PR DESCRIPTION
mailboxd/etc is needed to create the keystore on an appserver node.
Related: https://github.com/zextras/carbonio-core/pull/77