### PR TITLE
chore: [CO-2181] remove nginx-lookup-extension

### DIFF
--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -31,7 +31,6 @@ source=(
 
 sha256sums=(
   'SKIP'
-  'SKIP'
   'efd70576906f667cab1f2d21a31ddcd4250244be5f63b6465e22678aafc12413'
 )
 

--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -26,7 +26,6 @@ depends=(
 
 source=(
   "https://zextras.jfrog.io/artifactory/public-maven-repo/zimbra/zm-clam-scanner-store/22.3.0/zm-clam-scanner-store-22.3.0.jar"
-  "https://zextras.jfrog.io/artifactory/public-maven-repo/zimbra/zm-nginx-lookup-store/24.5.0/zm-nginx-lookup-store-24.5.0.jar"
   "${pkgname}.target"
 )
 
@@ -57,9 +56,6 @@ package() {
 
   install -D ${srcdir}/zm-clam-scanner-store-22.3.0.jar \
     -t "${pkgdir}/opt/zextras/lib/ext/clamscanner/"
-
-  install -D ${srcdir}/zm-nginx-lookup-store-24.5.0.jar \
-    -t "${pkgdir}/opt/zextras/lib/ext/nginx-lookup/"
 
   install -D conf/hotspot_compiler \
     "${pkgdir}/opt/zextras/log/.hotspot_compiler"


### PR DESCRIPTION
With these changes the extension will be built-in in the mailbox store jar.
Also it is not anymore required to build and publish [carbonio-nginx](https://github.com/zextras/carbonio-nginx-lookup-store/) and update the ref in this project PKGBUILD, making the release simpler.

Related PR: https://github.com/zextras/carbonio-mailbox/pull/759