### PR TITLE
IN-898 upgrade takes a lot of time because postinstall scripts of carbonio core mta appserver run chown r multiple times on store and backup paths

### DIFF
--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -111,7 +111,12 @@ postinst__apt() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
+  chown zextras:zextras \
+    /opt/zextras/redolog \
+    /opt/zextras/store \
+    /opt/zextras/index \
+    /opt/zextras/backup \
+    /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null
@@ -142,7 +147,12 @@ postinst__ubuntu_noble() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
+  chown zextras:zextras \
+    /opt/zextras/redolog \
+    /opt/zextras/store \
+    /opt/zextras/index \
+    /opt/zextras/backup \
+    /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null
@@ -190,7 +200,12 @@ postinst__rocky_8() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
+  chown zextras:zextras \
+    /opt/zextras/redolog \
+    /opt/zextras/store \
+    /opt/zextras/index \
+    /opt/zextras/backup \
+    /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null
@@ -221,7 +236,12 @@ postinst__rocky_9() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
+  chown zextras:zextras \
+    /opt/zextras/redolog \
+    /opt/zextras/store \
+    /opt/zextras/index \
+    /opt/zextras/backup \
+    /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null

--- a/appserver/PKGBUILD
+++ b/appserver/PKGBUILD
@@ -111,7 +111,7 @@ postinst__apt() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup
+  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null
@@ -142,7 +142,7 @@ postinst__ubuntu_noble() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup
+  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null
@@ -190,7 +190,7 @@ postinst__rocky_8() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup
+  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null
@@ -221,7 +221,7 @@ postinst__rocky_9() {
   mkdir -p /opt/zextras/store
   mkdir -p /opt/zextras/index
   mkdir -p /opt/zextras/backup
-  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup
+  chown zextras:zextras /opt/zextras/redolog /opt/zextras/store /opt/zextras/index /opt/zextras/backup /opt/zextras/cache
 
   if [ -d "/opt/zextras/mailboxd/work/zimbra" ]; then
     find /opt/zextras/mailboxd/work/zimbra -exec touch {} \; 2>/dev/null


### PR DESCRIPTION
Refs: IN-898